### PR TITLE
Fixed an issue where certain categories would not load

### DIFF
--- a/default.py
+++ b/default.py
@@ -181,7 +181,11 @@ def rssParser(data):
 			plot = infos[1].replace('\n','')+'\n\n'+infos[2]
 		link = re.compile('<link>(.+?)</link>', re.DOTALL).findall(item)[0]
 		link = link.replace('&amp;', '&')
-		documentId = link.split('documentId=')[1]
+		if 'documentId=' in link:
+			documentId = link.split('documentId=')[1]
+		else:
+			# Live streams have "kanal=" instead of "documentId="
+			continue
 		if '&' in documentId:
 			documentId = documentId.split('&')[0]
 		split = infos[2].split('|')


### PR DESCRIPTION
Some categories contain a Live stream in the rss fead that cannot be parsed by the plugin at the moment.
Example is category "Kinder & Familie"
This fix just ignores those entries.
